### PR TITLE
chore: use commitizen on commit hook

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+exec </dev/tty && yarn commit --hook || true


### PR DESCRIPTION
# What's done?

- Use commitizen to enter commit message via an interactive CLI.