### PR TITLE
chore: remove husky from pkg json

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+exec </dev/tty && yarn commit --hook || true

--- a/package.json
+++ b/package.json
@@ -111,12 +111,6 @@
   "resolutions": {
     "@types/react": "17.0.0"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
-  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
# What's done?

- Husky removed from pkg json as it's already defined in `.husky`