### PR TITLE
chore: remove prepare commit msg

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-exec </dev/tty && yarn commit --hook || true


### PR DESCRIPTION
# What's done?

- Removed prepare commit message husky hook as it doesn't work correctly when you merge/rebase